### PR TITLE
add MG to vardens version of CCAPS

### DIFF
--- a/incompressible/CCAPS/src/advance_module.f90
+++ b/incompressible/CCAPS/src/advance_module.f90
@@ -549,9 +549,23 @@ module advance_module
     divu = divu/dt
 
     if (use_vardens) then
-      call solve_variable_elliptic(phigs = phi, f = divu(1:nx,1:ny), &
-        & eta= 1.0_num / rho(0:nx+1,0:ny+1), &
-        & use_old_phi = .true., tol = 1e-18_num) 
+!      call solve_variable_elliptic(phigs = phi, f = divu(1:nx,1:ny), &
+!        & eta= 1.0_num / rho(0:nx+1,0:ny+1), &
+!        & use_old_phi = .true., tol = 1e-18_num) 
+
+      input = mg_input(tol = 1e-12_num, nx = nx, ny = ny, dx = dx, dy = dy, &
+            & f = divu(1:nx,1:ny), phi=phi, &
+            & bc_xmin = mg_bc_xmin, bc_xmax = mg_bc_xmax, &
+            & bc_ymin = mg_bc_ymin, bc_ymax = mg_bc_ymax, &
+            & eta = 1.0_num / rho(1:nx,1:ny), eta_present = .true., &
+            & eta_bc_xmin = mg_etabc_xmin, eta_bc_xmax = mg_etabc_xmax, &
+            & eta_bc_ymin = mg_etabc_ymin, eta_bc_ymax = mg_etabc_ymax, &
+            & etaval_bc_xmin = mg_etaval_bc_xmin, etaval_bc_ymin = mg_etaval_bc_ymin, &
+            & etaval_bc_xmax = mg_etaval_bc_xmax, etaval_bc_ymax = mg_etaval_bc_ymax )
+
+
+      call mg_interface(input)
+      phi = input%phi
     else
 !      call solve_const_Helmholtz(phigs = phi, f = divu(1:nx,1:ny), &
 !        alpha = 0.0_num, beta = -1.0_num, &

--- a/incompressible/CCAPS/src/advance_module.f90
+++ b/incompressible/CCAPS/src/advance_module.f90
@@ -336,9 +336,28 @@ module advance_module
     if (use_vardens) call rho_bcs ! needed for any OOB in relax and correction 
 
     if (use_vardens) then
-      call solve_variable_elliptic(phigs = phi, f = divu(1:nx,1:ny), &
-        & eta= 1.0_num / rho(0:nx+1,0:ny+1), &
-        & use_old_phi = .false., tol = 1e-18_num) 
+
+!      call solve_variable_elliptic(phigs = phi, f = divu(1:nx,1:ny), &
+!        & eta= 1.0_num / rho(0:nx+1,0:ny+1), &
+!        & use_old_phi = .false., tol = 1e-18_num) 
+
+      input = mg_input(tol = 1e-12_num, nx = nx, ny = ny, dx = dx, dy = dy, &
+            & f = divu(1:nx,1:ny), phi=phi, &
+            & bc_xmin = mg_bc_xmin, bc_xmax = mg_bc_xmax, &
+            & bc_ymin = mg_bc_ymin, bc_ymax = mg_bc_ymax, &
+            & eta = 1.0_num / rho(1:nx,1:ny), eta_present = .true., &
+            & eta_bc_xmin = mg_etabc_xmin, eta_bc_xmax = mg_etabc_xmax, &
+            & eta_bc_ymin = mg_etabc_ymin, eta_bc_ymax = mg_etabc_ymax, &
+            & etaval_bc_xmin = mg_etaval_bc_xmin, etaval_bc_ymin = mg_etaval_bc_ymin, &
+            & etaval_bc_xmax = mg_etaval_bc_xmax, etaval_bc_ymax = mg_etaval_bc_ymax )
+
+
+      call mg_interface(input)
+      phi = input%phi
+
+
+
+
     else
 !      call solve_const_Helmholtz(phigs = phi, f = divu(1:nx,1:ny), &
 !        & alpha = 0.0_num, beta = -1.0_num, &

--- a/incompressible/CCAPS/src/setup.f90
+++ b/incompressible/CCAPS/src/setup.f90
@@ -72,6 +72,27 @@ module setup
     if (bc_ymin == dirichlet) mg_bc_ymin = 'fixed'
     if (bc_ymax == dirichlet) mg_bc_ymax = 'fixed' !*
 
+    if (use_vardens) then
+
+      if (bc_xmin == periodic) mg_etabc_xmin = 'periodic'
+      if (bc_xmax == periodic) mg_etabc_xmax = 'periodic'
+      if (bc_ymin == periodic) mg_etabc_ymin = 'periodic'
+      if (bc_ymax == periodic) mg_etabc_ymax = 'periodic'
+
+      if (bc_xmin == no_slip) mg_etabc_xmin = 'fixed'
+      if (bc_xmax == no_slip) mg_etabc_xmax = 'fixed'
+      if (bc_ymin == no_slip) mg_etabc_ymin = 'fixed'
+      if (bc_ymax == no_slip) mg_etabc_ymax = 'fixed'
+
+      if (bc_xmin == no_slip) mg_etaval_bc_xmin = 1.0_num 
+      if (bc_xmax == no_slip) mg_etaval_bc_xmax = 1.0_num
+      if (bc_ymin == no_slip) mg_etaval_bc_ymin = 1.0_num
+      if (bc_ymax == no_slip) mg_etaval_bc_ymax = 7.0_num
+
+    endif ! use_vardens
+
+
+
 
   !* Drikkas and Rider suggest this a questionable way to sort solvability
 

--- a/incompressible/CCAPS/src/shared_data.f90
+++ b/incompressible/CCAPS/src/shared_data.f90
@@ -101,5 +101,14 @@ module shared_data
   character(len=20) :: mg_bc_ymin = 'none'
   character(len=20) :: mg_bc_ymax = 'none'
 
+  character(len=20) :: mg_etabc_xmin = 'none'
+  character(len=20) :: mg_etabc_xmax = 'none'
+  character(len=20) :: mg_etabc_ymin = 'none'
+  character(len=20) :: mg_etabc_ymax = 'none'
+
+  real(num) :: mg_etaval_bc_xmin = -1e6_num ! for dirichlet on eta
+  real(num) :: mg_etaval_bc_xmax = -1e6_num ! default to ridiculous num 
+  real(num) :: mg_etaval_bc_ymin = -1e6_num
+  real(num) :: mg_etaval_bc_ymax = -1e6_num !
 
 end module shared_data


### PR DESCRIPTION
- solve_variable_ellptic replaced with calls to the multigrid solver
- probs want to think about the best way to handle BCS and sort within CCAPS before going to replicate the multigrid calls in the spinoffs (CCAPS_vardens and CCAPS_atm) 